### PR TITLE
feat(model): Create QgsVectorLayer of consolidated nodes

### DIFF
--- a/tool/control.py
+++ b/tool/control.py
@@ -119,8 +119,6 @@ class ToolController:
 
     def onFinishedButton(self, state: ToolState) -> ToolState:
         if isinstance(state, ToolNodeComparisonState):
-            if not state.all_compared:
-                raise ControllerInvalidState
             return state.finish()
 
             # return ToolSpanComparisonState(newNetworks, ...)  # TODO

--- a/tool/control.py
+++ b/tool/control.py
@@ -121,7 +121,7 @@ class ToolController:
         if isinstance(state, ToolNodeComparisonState):
             if not state.all_compared:
                 raise ControllerInvalidState
-            raise NotImplementedError
+            return state.finish()
 
             # return ToolSpanComparisonState(newNetworks, ...)  # TODO
         elif isinstance(state, ToolSpanComparisonState):

--- a/tool/model/consolidation.py
+++ b/tool/model/consolidation.py
@@ -49,9 +49,15 @@ class NetworkNodesConsolidator:
             for b_node in self.network_b.nodes:
                 comparison = NodeComparison(a_node, b_node)
                 if comparison.distance_km > self.match_radius_km:
-                    continue
+                    # No chance of match, just add them both individually
+                    self.nodes.append(
+                        (comparison.node_a, ComparisonOutcome(consolidate=False))
+                    )
+                    self.nodes.append(
+                        (comparison.node_b, ComparisonOutcome(consolidate=False))
+                    )
 
-                if comparison.confidence >= self.merge_threshold:
+                elif comparison.confidence >= self.merge_threshold:
                     # Auto-consolidate
                     matching_properties = comparison.get_high_scoring_properties()
                     reason = ConsolidationReason(

--- a/tool/model/consolidation.py
+++ b/tool/model/consolidation.py
@@ -120,7 +120,7 @@ def qgis_layer_from_nodes(nodes: Set[Node]) -> QgsVectorLayer:
 
     # Remove an old intermediate layers from previous tool uses
     if len(project.mapLayersByName(LAYER_NAME)) > 0:
-        project.removeMapLayers(project.mapLayersByName(LAYER_NAME))
+        project.removeMapLayers([LAYER_NAME])
 
     # TODO: Change visibility from True to False when we're not testing anymore
     project.addMapLayer(layer, True)

--- a/tool/model/network.py
+++ b/tool/model/network.py
@@ -37,7 +37,7 @@ class Feature:
 
     def __hash__(self) -> int:
         # Enable Nodes/Spans to be put in a Set or Dict
-        return hash(self.id)
+        return hash((self.id, self.featureId, self.featureType))
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, Feature):

--- a/tool/view.py
+++ b/tool/view.py
@@ -388,7 +388,7 @@ class NodeComparisonView:
         self.progressBar.setValue(state.nCompared)
         self.progressBar.setFormat("%v of %m compared")
 
-        self.finishButton.setEnabled(state.all_compared)
+        self.finishButton.setEnabled(True)
 
     def _updateNotComparing(self):
         """

--- a/tool/view_warningbox.py
+++ b/tool/view_warningbox.py
@@ -4,7 +4,7 @@ from PyQt5.QtWidgets import QMessageBox
 from .model.network import Node
 
 
-def show_node_consolidation_warning(
+def show_node_multi_consolidation_warning(
     a_or_b: Literal["A", "B"], node: Node, other_node: Node
 ) -> bool:
     """
@@ -15,23 +15,49 @@ def show_node_consolidation_warning(
 
     This totally breaks the MVVM / MVC pattern we're using, but it works.
     """
+    title = f"Node {a_or_b} {node.name} already consolidated"
+    info_text = (
+        f"The node in Network {a_or_b}:\n\n"
+        + f"{node.name} (id = {node.id})\n\n"
+        + "has already been marked as the same as another node:\n\n"
+        + f"{other_node.name} (id = {other_node.id})).\n\n"
+        + " If you mark  this node as the same instead, this will"
+        + " override your previous match.\n"
+        + "Are you sure?"
+    )
+
+    return show_warningbox(title, info_text)
+
+
+def show_node_incomplete_consolidation_warning() -> bool:
+    title = "Warning: Not all Node comparisons have been marked"
+    info_text = (
+        "Not all Node comparisons have been marked as the same or not the same.\n"
+        + "If you continue, all remaining node comparisons will be marked as "
+        + "Not the Same, and you will move on to comparing spans.\n\n"
+        + "Are you sure you wish to finish comparing nodes?"
+    )
+
+    return show_warningbox(title, info_text, icon=QMessageBox.Icon.Warning)
+
+
+def show_warningbox(
+    title: str, info_text: str, icon: QMessageBox.Icon = QMessageBox.Icon.Question
+) -> bool:
+    """
+    This function shows a popup warning to the user, with the given title and info text,
+    and OK / Cancel buttons.
+
+    Returns True/False, True if the user clicks OK, False if Cancel.
+    """
+
     user_says_ok = False
 
     msg = QMessageBox()
     msg.setModal(True)
-    msg.setIcon(QMessageBox.Icon.Question)
-    msg.setWindowTitle(f"Node {a_or_b} {node.name} already consolidated")
-    msg.setInformativeText(
-        (
-            f"The node in Network {a_or_b}:\n\n"
-            + f"{node.name} (id = {node.id})\n\n"
-            + "has already been marked as the same as another node:\n\n"
-            + f"{other_node.name} (id = {other_node.id})).\n\n"
-            + " If you mark  this node as the same instead, this will"
-            + " override your previous match.\n"
-            + "Are you sure?"
-        )
-    )
+    msg.setIcon(icon)
+    msg.setWindowTitle(title)
+    msg.setInformativeText(info_text)
     msg.setStandardButtons(
         QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel
     )

--- a/tool/viewmodel/state.py
+++ b/tool/viewmodel/state.py
@@ -188,7 +188,7 @@ class ToolNodeComparisonState(AbstractToolState):
     def finish(self):
         if not self.all_compared:
             raise ToolInvalidState(
-                "Tried to finish Nodes comparison with comparing all nodes"
+                "Tried to finish Nodes comparison without comparing all nodes"
             )
 
         self.nodes_consolidator.finalise_with_user_comparison_outcomes(

--- a/tool/viewmodel/state.py
+++ b/tool/viewmodel/state.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, List, Union, Tuple
+from typing import ClassVar, List, Union, Tuple, cast
 from enum import Enum
 
 
@@ -184,6 +184,22 @@ class ToolNodeComparisonState(AbstractToolState):
             return self.comparisons_outcomes[self.current][1]
         except IndexError:
             return None
+
+    def finish(self):
+        if not self.all_compared:
+            raise ToolInvalidState(
+                "Tried to finish Nodes comparison with comparing all nodes"
+            )
+
+        self.nodes_consolidator.finalise_with_user_comparison_outcomes(
+            cast(
+                List[Tuple[NodeComparison, ComparisonOutcome]],
+                self.comparisons_outcomes,
+            )
+        )
+
+        consolidated_network = self.nodes_consolidator.get_consolidated_network()
+        return ToolSpanComparisonState()
 
 
 class ToolSpanComparisonState(AbstractToolState):


### PR DESCRIPTION
This PR implements creating an intermediate QGIS layer containing the consolidated nodes.

The purpose of the layer during spans comparison is to be a spacial index (compare span endpoints to node locations?) and to display nodes in the minimaps.

Now, when pressing the "Finish" button in Nodes Comparison screen, it will create a new layer called `_ofds_consolidated_nodes` in the QGIS project.