### PR TITLE
Add provenance data to output

### DIFF
--- a/docs/howto.md
+++ b/docs/howto.md
@@ -143,7 +143,7 @@ If you choose "Basic", each feature will have an additional `provenance` field:
 * `generatedAtTime`: date or datetime the network was generated.
 * `confidence`: a score between 0 and 1 representing how likely the two source features are the same.
 * `similarFields`: array of field names for fields with high similarity scores between the two features.
-* `automatic`: bool; false means the merge was confirmed manually by the user; true means it was done by the tool.
+* `manual`: bool; true means the merge was confirmed manually by the user; false means it was done by the tool.
 
 ```
 {
@@ -167,10 +167,10 @@ If you choose "Basic", each feature will have an additional `provenance` field:
 			},
 			"provenance": {
 				"wasDerivedFrom": ["f787b3ce-dc40-4d09-ac8a-78ded5811578", "debba101-49e9-4454-a613-f474dcc73f1c"],
-				"generatedAtTime": "2024-04-04",
+				"generatedAtTime": "2024-04-04T14:34:56+00:00",
 				"confidence": 0.89,
 				"similarFields": ["name", "coordinates", "status"],
-				"automatic": "false"
+				"manual": "true"
 			}
 		},
 		{
@@ -188,7 +188,7 @@ _And_ the whole network will contain a copy of the source of both original netwo
 
 * `allFieldScores`: an object where the properties are the field names used for comparision, and the values are the similarity scores between 0 and 1 for each.
 * `merged`: bool; false means the features were not consolidated together; true means they were.
-* `automatic`: the same as this property on individual features in a consolidated network, but note that if `automatic` is `true` and `merged` is `false` it means the tool automatically did not consolidate two features without prompting the user to confirm.
+* `manual`: the same as this property on individual features in a consolidated network, but note that if `manual` is `false` and `merged` is `false` it means the tool automatically did not consolidate two features without prompting the user to confirm.
 
 If "include non-matches" is set, the source and scores of both original networks for all features which were _compared_ are included, even if they were not consolidated:
 
@@ -217,7 +217,7 @@ If "include non-matches" is set, the source and scores of both original networks
 				"generatedAtTime": "2024-04-04",
 				"confidence": 0.89,
 				"similarFieldScores": {"name": 1, "coordinates": 0.8, "status": 1},
-				"automatic": "false"
+				"manual": "true"
 			}
 		},
 		{
@@ -263,7 +263,7 @@ If "include non-matches" is set, the source and scores of both original networks
 		"confidence": 0.29,
 		"allFieldScores": {"name": 0.1, "coordinates": 0.4, "status": 1, "type": 0, "power": 0},
 		"merged": "false",
-		"automatic": "true"
+		"manual": "false"
 	]
 }
 ```

--- a/tests/test_consolidation.py
+++ b/tests/test_consolidation.py
@@ -74,7 +74,7 @@ def test_consolidation(qgis_app, qgis_new_project, request):
                 primary=comparison.feature_a,
                 secondary=comparison.feature_b,
                 confidence=comparison.confidence,
-                matching_properties=comparison.get_high_scoring_properties(),
+                similar_fields=comparison.get_high_scoring_properties(),
                 manual=True,
             ),
         )
@@ -108,7 +108,7 @@ def test_consolidation(qgis_app, qgis_new_project, request):
                 primary=sc.feature_a,
                 secondary=sc.feature_b,
                 confidence=sc.confidence,
-                matching_properties=sc.get_high_scoring_properties(),
+                similar_fields=sc.get_high_scoring_properties(),
                 manual=True,
             ),
         )

--- a/tool/model/comparison.py
+++ b/tool/model/comparison.py
@@ -444,7 +444,7 @@ class ConsolidationReason:
     primary: Feature
     secondary: Feature
     confidence: float
-    matching_properties: List[str]
+    similar_fields: List[str]
     manual: bool = False
 
 

--- a/tool/model/consolidation.py
+++ b/tool/model/consolidation.py
@@ -117,13 +117,13 @@ class NetworkNodesConsolidator(AbstractNetworkConsolidator[Node, NodeComparison]
 
                 elif comparison.confidence > self.merge_threshold:
                     # Auto-consolidate
-                    matching_properties = comparison.get_high_scoring_properties()
+                    similar_fields = comparison.get_high_scoring_properties()
                     reason = ConsolidationReason(
                         feature_type="NODE",
                         primary=comparison.node_a,
                         secondary=comparison.node_b,
                         confidence=comparison.confidence,
-                        matching_properties=matching_properties,
+                        similar_fields=similar_fields,
                         manual=False,
                     )
                     outcome = NodeComparisonOutcome(

--- a/tool/model/properties.py
+++ b/tool/model/properties.py
@@ -1,4 +1,5 @@
 import logging
+import datetime
 
 from pprint import pprint
 from typing import Dict, Any, List, Tuple
@@ -131,3 +132,22 @@ def merge_features_properties(
     pprint(props)
 
     return props
+
+
+def generate_provenance_data(consolidation_reason):
+    """
+    Additional metadata about the origin of a consolidated feature.
+    Property names are in line with PROV-O vocab where applicable, and
+    use camelCase to serialise directly to JSON.
+    """
+    primary_id = consolidation_reason.primary.get("id")
+    secondary_id = consolidation_reason.secondary.get("id")
+    prov = {
+        "wasDerivedFrom": [primary_id, secondary_id], # TODO: include filenames here
+        "generatedAtTime": datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat(),
+        "confidence": consolidation_reason.confidence,
+        "similarFields": consolidation_reason.similar_fields,
+        "manual": consolidation_reason.manual,
+    }
+
+    return prov

--- a/tool/viewmodel/state.py
+++ b/tool/viewmodel/state.py
@@ -209,7 +209,7 @@ class AbstractToolComparisonState(Generic[FeatureT, ComparisonT], AbstractToolSt
             secondary=comparison.feature_b,
             confidence=comparison.confidence,
             # TODO: user's choice of matching properties? User text message?
-            matching_properties=comparison.get_high_scoring_properties(),
+            similar_fields=comparison.get_high_scoring_properties(),
             manual=True,
         )
 


### PR DESCRIPTION
In the form:

```
{
  "wasDerivedFrom": [primary_id, secondary_id],
  "generatedAtTime": ISO 86301 datetime with tz info in UTC,
  "confidence": confidence score,
  "similarFields": [ .. ],
  "manual": bool
}
```