### PR TITLE
Increase threshold for 'strong' match to 0.75

### DIFF
--- a/tool/model/comparison.py
+++ b/tool/model/comparison.py
@@ -62,8 +62,9 @@ class Comparison:
         self.confidence = self.total / highest * 100
 
     def get_high_scoring_properties(self):
-        # Return scores that are over 0.5 - this is arbitrary, may want to increase
-        return [k for k, v in self.scores.items() if v > 0.5]
+        # Return scores that are over 0.75
+        # This is used to explain the overall similarity score. Appears in provenance data and UI.
+        return [k for k, v in self.scores.items() if v > 0.75]
 
     def compare_equals(self, first, second):
         if first == second and first is not None:


### PR DESCRIPTION
Based on feedback in https://github.com/Open-Telecoms-Data/ofds_consolidation_tool/pull/53#issuecomment-2165343387, this might make the 'strong matches' part of the UI a bit more sensical, but there will be less data in the provenance output, because it currently doesn't include any information on non-strong matches.